### PR TITLE
fix make errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,5 +31,6 @@ add_executable(jump_table examples/jump_table/jump_table.cpp
                ${CMAKE_CURRENT_BINARY_DIR}/lift.o)
 
 target_compile_features(jump_table PRIVATE cxx_std_20)
+target_include_directories(jump_table PRIVATE /usr/lib/ocaml/)
 target_link_directories(jump_table PRIVATE /usr/lib/ocaml/)
 target_link_libraries(jump_table PRIVATE asmrun_shared camlstr)

--- a/include/sba/system.h
+++ b/include/sba/system.h
@@ -16,6 +16,7 @@
 #include <utility>
 #include <tuple>
 #include <fstream>
+#include <cstdint>
 #include "config.h"
  
 namespace SBA {


### PR DESCRIPTION
1. /home/haco/sba/src/sba/framework.cpp:14:10: fatal error: caml/alloc.h: No such file or directory
   14 | #include <caml/alloc.h>
2. error: ‘uint8_t’ was not declared in this scope